### PR TITLE
Pass limit option to iterator

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -443,6 +443,7 @@ class DB {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: true,
       values: true
     });
@@ -465,6 +466,7 @@ class DB {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: true,
       values: false
     });
@@ -487,6 +489,7 @@ class DB {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: false,
       values: true
     });
@@ -825,6 +828,7 @@ class Bucket {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: true,
       values: true
     });
@@ -847,6 +851,7 @@ class Bucket {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: true,
       values: false
     });
@@ -869,6 +874,7 @@ class Bucket {
       lt: options.lt,
       gte: options.gte,
       lte: options.lte,
+      limit: options.limit,
       keys: false,
       values: true
     });


### PR DESCRIPTION
Several methods don't pass `limit` to the iterator: `keys`, `values`, `range`.