### PR TITLE
Fix segmentation faults with bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bdb",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2,6 +2,7 @@
 
 #include "napi-macros.h"
 #include <node_api.h>
+#include <assert.h>
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
@@ -236,7 +237,12 @@ static napi_status CallFunction (napi_env env,
 }
 
 /**
- * Base worker class. Handles the async work.
+ * Base worker class. Handles the async work. Derived classes can override the
+ * following virtual methods (listed in the order in which they're called):
+ *
+ * - DoExecute (abstract, worker pool thread): main work
+ * - HandleOKCallback (main thread): call JS callback on success
+ * - DoFinally (main thread): do cleanup regardless of success
  */
 struct BaseWorker {
   BaseWorker (napi_env env,
@@ -244,12 +250,12 @@ struct BaseWorker {
               napi_value callback,
               const char* resourceName)
     : env_(env), database_(database), errMsg_(NULL) {
-    NAPI_STATUS_THROWS(napi_create_reference(env_, callback, 1, &callbackRef_));
+    NAPI_STATUS_THROWS_VOID(napi_create_reference(env_, callback, 1, &callbackRef_));
     napi_value asyncResourceName;
-    NAPI_STATUS_THROWS(napi_create_string_utf8(env_, resourceName,
+    NAPI_STATUS_THROWS_VOID(napi_create_string_utf8(env_, resourceName,
                                                NAPI_AUTO_LENGTH,
                                                &asyncResourceName));
-    NAPI_STATUS_THROWS(napi_create_async_work(env_, callback,
+    NAPI_STATUS_THROWS_VOID(napi_create_async_work(env_, callback,
                                               asyncResourceName,
                                               BaseWorker::Execute,
                                               BaseWorker::Complete,
@@ -282,10 +288,12 @@ struct BaseWorker {
   }
 
   virtual void DoExecute () = 0;
+  virtual void DoFinally () {};
 
   static void Complete (napi_env env, napi_status status, void* data) {
     BaseWorker* self = (BaseWorker*)data;
     self->DoComplete();
+    self->DoFinally();
     delete self;
   }
 
@@ -332,7 +340,8 @@ struct Database {
       blockCache_(NULL),
       filterPolicy_(leveldb::NewBloomFilterPolicy(10)),
       currentIteratorId_(0),
-      pendingCloseWorker_(NULL) {}
+      pendingCloseWorker_(NULL),
+      priorityWork_(0) {}
 
   ~Database () {
     if (db_ != NULL) {
@@ -404,12 +413,29 @@ struct Database {
     return db_->ReleaseSnapshot(snapshot);
   }
 
-  void ReleaseIterator (uint32_t id) {
+  void AttachIterator (uint32_t id, Iterator* iterator) {
+    iterators_[id] = iterator;
+    IncrementPriorityWork();
+  }
+
+  void DetachIterator (uint32_t id) {
     iterators_.erase(id);
-    if (iterators_.empty() && pendingCloseWorker_ != NULL) {
+    DecrementPriorityWork();
+  }
+
+  void IncrementPriorityWork () {
+    ++priorityWork_;
+  }
+
+  void DecrementPriorityWork () {
+    if (--priorityWork_ == 0 && pendingCloseWorker_ != NULL) {
       pendingCloseWorker_->Queue();
       pendingCloseWorker_ = NULL;
     }
+  }
+
+  bool HasPriorityWork () {
+    return priorityWork_ > 0;
   }
 
   napi_env env_;
@@ -419,6 +445,9 @@ struct Database {
   uint32_t currentIteratorId_;
   BaseWorker *pendingCloseWorker_;
   std::map< uint32_t, Iterator * > iterators_;
+
+private:
+  uint32_t priorityWork_;
 };
 
 /**
@@ -429,6 +458,22 @@ static void FinalizeDatabase (napi_env env, void* data, void* hint) {
     delete (Database*)data;
   }
 }
+
+/**
+ * Base worker class for doing async work that defers closing the database.
+ */
+struct PriorityWorker : public BaseWorker {
+  PriorityWorker (napi_env env, Database* database, napi_value callback, const char* resourceName)
+    : BaseWorker(env, database, callback, resourceName) {
+      database_->IncrementPriorityWork();
+  }
+
+  ~PriorityWorker () {}
+
+  void DoFinally () override {
+    database_->DecrementPriorityWork();
+  }
+};
 
 /**
  * Owns a leveldb iterator.
@@ -472,13 +517,15 @@ struct Iterator {
       landed_(false),
       nexting_(false),
       ended_(false),
-      endWorker_(NULL) {
+      endWorker_(NULL),
+      ref_(NULL) {
     options_ = new leveldb::ReadOptions();
     options_->fill_cache = fillCache;
     options_->snapshot = database->NewSnapshot();
   }
 
   ~Iterator () {
+    assert(ended_);
     ReleaseTarget();
     if (start_ != NULL) {
       // Special case for `start` option: it won't be
@@ -506,6 +553,7 @@ struct Iterator {
     if (gte_ != NULL) {
       delete gte_;
     }
+    delete options_;
   }
 
   void ReleaseTarget () {
@@ -518,8 +566,14 @@ struct Iterator {
     }
   }
 
-  void Release () {
-    database_->ReleaseIterator(id_);
+  void Attach (napi_ref ref) {
+    ref_ = ref;
+    database_->AttachIterator(id_, this);
+  }
+
+  napi_ref Detach () {
+    database_->DetachIterator(id_);
+    return ref_;
   }
 
   leveldb::Status IteratorStatus () {
@@ -635,6 +689,8 @@ struct Iterator {
 
   bool IteratorNext (std::vector<std::pair<std::string, std::string> >& result) {
     size_t size = 0;
+    uint32_t cacheSize = 0;
+
     while (true) {
       std::string key, value;
       bool ok = Read(key, value);
@@ -650,6 +706,9 @@ struct Iterator {
         size = size + key.size() + value.size();
         if (size > highWaterMark_) return true;
 
+        // Limit the size of the cache to prevent starving the event loop
+        // in JS-land while we're recursively calling process.nextTick().
+        if (++cacheSize >= 1000) return true;
       } else {
         return false;
       }
@@ -681,6 +740,9 @@ struct Iterator {
 
   leveldb::ReadOptions* options_;
   EndWorker* endWorker_;
+
+private:
+  napi_ref ref_;
 };
 
 /**
@@ -699,7 +761,7 @@ NAPI_METHOD(db_init) {
 /**
  * Worker class for opening a database.
  */
-struct OpenWorker : public BaseWorker {
+struct OpenWorker final : public BaseWorker {
   OpenWorker (napi_env env,
               Database* database,
               napi_value callback,
@@ -728,9 +790,9 @@ struct OpenWorker : public BaseWorker {
     options_.max_file_size = maxFileSize;
   }
 
-  virtual ~OpenWorker () {}
+  ~OpenWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     SetStatus(database_->Open(options_, location_.c_str()));
   }
 
@@ -776,15 +838,15 @@ NAPI_METHOD(db_open) {
 /**
  * Worker class for closing a database
  */
-struct CloseWorker : public BaseWorker {
+struct CloseWorker final : public BaseWorker {
   CloseWorker (napi_env env,
                Database* database,
                napi_value callback)
     : BaseWorker(env, database, callback, "leveldown.db.close") {}
 
-  virtual ~CloseWorker () {}
+  ~CloseWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     database_->CloseDatabase();
   }
 };
@@ -803,7 +865,7 @@ NAPI_METHOD(db_close) {
   napi_value callback = argv[1];
   CloseWorker* worker = new CloseWorker(env, database, callback);
 
-  if (database->iterators_.empty()) {
+  if (!database->HasPriorityWork()) {
     worker->Queue();
     NAPI_RETURN_UNDEFINED();
   }
@@ -813,13 +875,11 @@ NAPI_METHOD(db_close) {
   napi_value noop;
   napi_create_function(env, NULL, 0, noop_callback, NULL, &noop);
 
-  std::map< uint32_t, Iterator * >::iterator it;
-  for (it = database->iterators_.begin();
-       it != database->iterators_.end(); ++it) {
-    Iterator *iterator = it->second;
-    if (!iterator->ended_) {
-      iterator_end_do(env, iterator, noop);
-    }
+  std::map<uint32_t, Iterator*> iterators = database->iterators_;
+  std::map<uint32_t, Iterator*>::iterator it;
+
+  for (it = iterators.begin(); it != iterators.end(); ++it) {
+    iterator_end_do(env, it->second, noop);
   }
 
   NAPI_RETURN_UNDEFINED();
@@ -828,24 +888,24 @@ NAPI_METHOD(db_close) {
 /**
  * Worker class for putting key/value to the database
  */
-struct PutWorker : public BaseWorker {
+struct PutWorker final : public PriorityWorker {
   PutWorker (napi_env env,
              Database* database,
              napi_value callback,
              leveldb::Slice key,
              leveldb::Slice value,
              bool sync)
-    : BaseWorker(env, database, callback, "leveldown.db.put"),
+    : PriorityWorker(env, database, callback, "leveldown.db.put"),
       key_(key), value_(value) {
     options_.sync = sync;
   }
 
-  virtual ~PutWorker () {
+  ~PutWorker () {
     DisposeSliceBuffer(key_);
     DisposeSliceBuffer(value_);
   }
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     SetStatus(database_->Put(options_, key_, value_));
   }
 
@@ -875,28 +935,28 @@ NAPI_METHOD(db_put) {
 /**
  * Worker class for getting a value from a database.
  */
-struct GetWorker : public BaseWorker {
+struct GetWorker final : public PriorityWorker {
   GetWorker (napi_env env,
              Database* database,
              napi_value callback,
              leveldb::Slice key,
              bool asBuffer,
              bool fillCache)
-    : BaseWorker(env, database, callback, "leveldown.db.get"),
+    : PriorityWorker(env, database, callback, "leveldown.db.get"),
       key_(key),
       asBuffer_(asBuffer) {
     options_.fill_cache = fillCache;
   }
 
-  virtual ~GetWorker () {
+  ~GetWorker () {
     DisposeSliceBuffer(key_);
   }
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     SetStatus(database_->Get(options_, key_, value_));
   }
 
-  virtual void HandleOKCallback() {
+  void HandleOKCallback () override {
     napi_value argv[2];
     napi_get_null(env_, &argv[0]);
 
@@ -940,22 +1000,22 @@ NAPI_METHOD(db_get) {
 /**
  * Worker class for deleting a value from a database.
  */
-struct DelWorker : public BaseWorker {
+struct DelWorker final : public PriorityWorker {
   DelWorker (napi_env env,
              Database* database,
              napi_value callback,
              leveldb::Slice key,
              bool sync)
-    : BaseWorker(env, database, callback, "leveldown.db.del"),
+    : PriorityWorker(env, database, callback, "leveldown.db.del"),
       key_(key) {
     options_.sync = sync;
   }
 
-  virtual ~DelWorker () {
+  ~DelWorker () {
     DisposeSliceBuffer(key_);
   }
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     SetStatus(database_->Del(options_, key_));
   }
 
@@ -983,26 +1043,26 @@ NAPI_METHOD(db_del) {
 /**
  * Worker class for calculating the size of a range.
  */
-struct ApproximateSizeWorker : public BaseWorker {
+struct ApproximateSizeWorker final : public PriorityWorker {
   ApproximateSizeWorker (napi_env env,
                          Database* database,
                          napi_value callback,
                          leveldb::Slice start,
                          leveldb::Slice end)
-    : BaseWorker(env, database, callback, "leveldown.db.approximate_size"),
+    : PriorityWorker(env, database, callback, "leveldown.db.approximate_size"),
       start_(start), end_(end) {}
 
-  virtual ~ApproximateSizeWorker () {
+  ~ApproximateSizeWorker () {
     DisposeSliceBuffer(start_);
     DisposeSliceBuffer(end_);
   }
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     leveldb::Range range(start_, end_);
     size_ = database_->ApproximateSize(&range);
   }
 
-  virtual void HandleOKCallback() {
+  void HandleOKCallback () override {
     napi_value argv[2];
     napi_get_null(env_, &argv[0]);
     napi_create_uint32(env_, (uint32_t)size_, &argv[1]);
@@ -1039,21 +1099,21 @@ NAPI_METHOD(db_approximate_size) {
 /**
  * Worker class for compacting a range in a database.
  */
-struct CompactRangeWorker : public BaseWorker {
+struct CompactRangeWorker final : public PriorityWorker {
   CompactRangeWorker (napi_env env,
                       Database* database,
                       napi_value callback,
                       leveldb::Slice start,
                       leveldb::Slice end)
-    : BaseWorker(env, database, callback, "leveldown.db.compact_range"),
+    : PriorityWorker(env, database, callback, "leveldown.db.compact_range"),
       start_(start), end_(end) {}
 
-  virtual ~CompactRangeWorker () {
+  ~CompactRangeWorker () {
     DisposeSliceBuffer(start_);
     DisposeSliceBuffer(end_);
   }
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     database_->CompactRange(&start_, &end_);
   }
 
@@ -1102,16 +1162,16 @@ NAPI_METHOD(db_get_property) {
 /**
  * Worker class for destroying a database.
  */
-struct DestroyWorker : public BaseWorker {
+struct DestroyWorker final : public BaseWorker {
   DestroyWorker (napi_env env,
                  const std::string& location,
                  napi_value callback)
     : BaseWorker(env, NULL, callback, "leveldown.destroy_db"),
       location_(location) {}
 
-  virtual ~DestroyWorker () {}
+  ~DestroyWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     leveldb::Options options;
     SetStatus(leveldb::DestroyDB(location_, options));
   }
@@ -1138,16 +1198,16 @@ NAPI_METHOD(destroy_db) {
 /**
  * Worker class for repairing a database.
  */
-struct RepairWorker : public BaseWorker {
+struct RepairWorker final : public BaseWorker {
   RepairWorker (napi_env env,
                 const std::string& location,
                 napi_value callback)
     : BaseWorker(env, NULL, callback, "leveldown.repair_db"),
       location_(location) {}
 
-  virtual ~RepairWorker () {}
+  ~RepairWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     leveldb::Options options;
     SetStatus(leveldb::RepairDB(location_, options));
   }
@@ -1292,12 +1352,18 @@ NAPI_METHOD(iterator_init) {
   Iterator* iterator = new Iterator(database, id, start, end, reverse, keys,
                                     values, limit, lt, lte, gt, gte, fillCache,
                                     keyAsBuffer, valueAsBuffer, highWaterMark);
-  database->iterators_[id] = iterator;
-
   napi_value result;
+  napi_ref ref;
+
   NAPI_STATUS_THROWS(napi_create_external(env, iterator,
                                           FinalizeIterator,
                                           NULL, &result));
+
+  // Prevent GC of JS object before the iterator is ended (explicitly or on
+  // db close) and keep track of non-ended iterators to end them on db close.
+  NAPI_STATUS_THROWS(napi_create_reference(env, result, 1, &ref));
+  iterator->Attach(ref);
+
   return result;
 }
 
@@ -1307,6 +1373,10 @@ NAPI_METHOD(iterator_init) {
 NAPI_METHOD(iterator_seek) {
   NAPI_ARGV(2);
   NAPI_ITERATOR_CONTEXT();
+
+  if (iterator->ended_) {
+    napi_throw_error(env, NULL, "iterator has ended");
+  }
 
   iterator->ReleaseTarget();
   iterator->target_ = new leveldb::Slice(ToSlice(env, argv[1]));
@@ -1358,21 +1428,21 @@ NAPI_METHOD(iterator_seek) {
 /**
  * Worker class for ending an iterator
  */
-struct EndWorker : public BaseWorker {
+struct EndWorker final : public BaseWorker {
   EndWorker (napi_env env,
              Iterator* iterator,
              napi_value callback)
     : BaseWorker(env, iterator->database_, callback, "leveldown.iterator.end"),
       iterator_(iterator) {}
 
-  virtual ~EndWorker () {}
+  ~EndWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     iterator_->IteratorEnd();
   }
 
-  virtual void HandleOKCallback () {
-    iterator_->Release();
+  void HandleOKCallback () override {
+    napi_delete_reference(env_, iterator_->Detach());
     BaseWorker::HandleOKCallback();
   }
 
@@ -1424,7 +1494,7 @@ void CheckEndCallback (Iterator* iterator) {
 /**
  * Worker class for nexting an iterator.
  */
-struct NextWorker : public BaseWorker {
+struct NextWorker final : public BaseWorker {
   NextWorker (napi_env env,
               Iterator* iterator,
               napi_value callback,
@@ -1434,16 +1504,16 @@ struct NextWorker : public BaseWorker {
       iterator_(iterator),
       localCallback_(localCallback) {}
 
-  virtual ~NextWorker () {}
+  ~NextWorker () {}
 
-  virtual void DoExecute () {
+  void DoExecute () override {
     ok_ = iterator_->IteratorNext(result_);
     if (!ok_) {
       SetStatus(iterator_->IteratorStatus());
     }
   }
 
-  virtual void HandleOKCallback () {
+  void HandleOKCallback () override {
     size_t arraySize = result_.size() * 2;
     napi_value jsArray;
     napi_create_array_with_length(env_, arraySize, &jsArray);
@@ -1519,27 +1589,31 @@ NAPI_METHOD(iterator_next) {
 /**
  * Worker class for batch write operation.
  */
-struct BatchWorker : public BaseWorker {
+struct BatchWorker final : public PriorityWorker {
   BatchWorker (napi_env env,
                Database* database,
                napi_value callback,
                leveldb::WriteBatch* batch,
-               bool sync)
-    : BaseWorker(env, database, callback, "leveldown.batch.do"),
-      batch_(batch) {
+               bool sync,
+               bool hasData)
+    : PriorityWorker(env, database, callback, "leveldown.batch.do"),
+      batch_(batch), hasData_(hasData) {
     options_.sync = sync;
   }
 
-  virtual ~BatchWorker () {
+  ~BatchWorker () {
     delete batch_;
   }
 
-  virtual void DoExecute () {
-    SetStatus(database_->WriteBatch(options_, batch_));
+  void DoExecute () override {
+    if (hasData_) {
+      SetStatus(database_->WriteBatch(options_, batch_));
+    }
   }
 
   leveldb::WriteOptions options_;
   leveldb::WriteBatch* batch_;
+  bool hasData_;
 };
 
 /**
@@ -1590,15 +1664,8 @@ NAPI_METHOD(batch_do) {
     }
   }
 
-  if (hasData) {
-    BatchWorker* worker = new BatchWorker(env, database, callback, batch, sync);
-    worker->Queue();
-  } else {
-    delete batch;
-    napi_value argv;
-    napi_get_null(env, &argv);
-    CallFunction(env, callback, 1, &argv);
-  }
+  BatchWorker* worker = new BatchWorker(env, database, callback, batch, sync, hasData);
+  worker->Queue();
 
   NAPI_RETURN_UNDEFINED();
 }
@@ -1712,23 +1779,34 @@ NAPI_METHOD(batch_clear) {
 /**
  * Worker class for batch write operation.
  */
-struct BatchWriteWorker : public BaseWorker {
+struct BatchWriteWorker final : public PriorityWorker {
   BatchWriteWorker (napi_env env,
+                    napi_value context,
                     Batch* batch,
                     napi_value callback,
                     bool sync)
-    : BaseWorker(env, batch->database_, callback, "leveldown.batch.write"),
+    : PriorityWorker(env, batch->database_, callback, "leveldown.batch.write"),
       batch_(batch),
-      sync_(sync) {}
+      sync_(sync) {
+        // Prevent GC of batch object before we execute
+        NAPI_STATUS_THROWS_VOID(napi_create_reference(env_, context, 1, &contextRef_));
+      }
 
-  virtual ~BatchWriteWorker () {}
+  ~BatchWriteWorker () {
+    napi_delete_reference(env_, contextRef_);
+  }
 
-  virtual void DoExecute () {
-    SetStatus(batch_->Write(sync_));
+  void DoExecute () override {
+    if (batch_->hasData_) {
+      SetStatus(batch_->Write(sync_));
+    }
   }
 
   Batch* batch_;
   bool sync_;
+
+private:
+  napi_ref contextRef_;
 };
 
 /**
@@ -1742,7 +1820,7 @@ NAPI_METHOD(batch_write) {
   bool sync = BooleanProperty(env, options, "sync", false);
   napi_value callback = argv[2];
 
-  BatchWriteWorker* worker  = new BatchWriteWorker(env, batch, callback, sync);
+  BatchWriteWorker* worker  = new BatchWriteWorker(env, argv[0], batch, callback, sync);
   worker->Queue();
 
   NAPI_RETURN_UNDEFINED();

--- a/src/napi-macros.h
+++ b/src/napi-macros.h
@@ -17,9 +17,16 @@
     napi_fatal_exception(env, fatal_exception); \
   }
 
+#define NAPI_STATUS_THROWS_VOID(call) \
+  if ((call) != napi_ok) { \
+    napi_throw_error(env, NULL, #call " failed!"); \
+    return; \
+  }
+
 #define NAPI_STATUS_THROWS(call) \
   if ((call) != napi_ok) { \
     napi_throw_error(env, NULL, #call " failed!"); \
+    return NULL; \
   }
 
 #define NAPI_METHOD(name) \
@@ -39,8 +46,8 @@
     void *ptr = &(tmp.name); \
     void *ptr_base = &tmp; \
     int offset = (char *) ptr - (char *) ptr_base; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, offset, &name##_offsetof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "offsetof_" #type "_" #name, name##_offsetof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, offset, &name##_offsetof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "offsetof_" #type "_" #name, name##_offsetof)) \
   }
 
 #define NAPI_EXPORT_OFFSETOF_STRUCT(type, name) \
@@ -50,8 +57,8 @@
     void *ptr = &(tmp.name); \
     void *ptr_base = &tmp; \
     int offset = (char *) ptr - (char *) ptr_base; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, offset, &name##_offsetof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "offsetof_struct_" #type "_" #name, name##_offsetof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, offset, &name##_offsetof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "offsetof_struct_" #type "_" #name, name##_offsetof)) \
   }
 
 
@@ -62,8 +69,8 @@
       char a; \
       name b; \
     }; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, sizeof(struct tmp) - sizeof(name), &name##_alignmentof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "alignmentof_" #name, name##_alignmentof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, sizeof(struct tmp) - sizeof(name), &name##_alignmentof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "alignmentof_" #name, name##_alignmentof)) \
   }
 
 #define NAPI_EXPORT_ALIGNMENTOF_STRUCT(name) \
@@ -73,50 +80,50 @@
       char a; \
       struct name b; \
     }; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, sizeof(struct tmp) - sizeof(struct name), &name##_alignmentof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "alignmentof_" #name, name##_alignmentof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, sizeof(struct tmp) - sizeof(struct name), &name##_alignmentof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "alignmentof_" #name, name##_alignmentof)) \
   }
 
 #define NAPI_EXPORT_SIZEOF(name) \
   { \
     napi_value name##_sizeof; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, sizeof(name), &name##_sizeof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "sizeof_" #name, name##_sizeof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, sizeof(name), &name##_sizeof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "sizeof_" #name, name##_sizeof)) \
   }
 
 #define NAPI_EXPORT_SIZEOF_STRUCT(name) \
   { \
     napi_value name##_sizeof; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, sizeof(struct name), &name##_sizeof)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, "sizeof_" #name, name##_sizeof)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, sizeof(struct name), &name##_sizeof)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, "sizeof_" #name, name##_sizeof)) \
   }
 
 #define NAPI_EXPORT_UINT32(name) \
   { \
     napi_value name##_uint32; \
-    NAPI_STATUS_THROWS(napi_create_uint32(env, name, &name##_uint32)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, #name, name##_uint32)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_uint32(env, name, &name##_uint32)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, #name, name##_uint32)) \
   }
 
 #define NAPI_EXPORT_INT32(name) \
   { \
     napi_value name##_int32; \
-    NAPI_STATUS_THROWS(napi_create_int32(env, name, &name##_int32)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, #name, name##_int32)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_int32(env, name, &name##_int32)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, #name, name##_int32)) \
   }
 
 #define NAPI_EXPORT_FUNCTION(name) \
   { \
     napi_value name##_fn; \
-    NAPI_STATUS_THROWS(napi_create_function(env, NULL, 0, name, NULL, &name##_fn)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, #name, name##_fn)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_function(env, NULL, 0, name, NULL, &name##_fn)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, #name, name##_fn)) \
   }
 
 #define NAPI_EXPORT_UTF8(name, len) \
   { \
     napi_value name##_utf8; \
-    NAPI_STATUS_THROWS(napi_create_string_utf8(env, name, len, &name##_utf8)) \
-    NAPI_STATUS_THROWS(napi_set_named_property(env, exports, #name, name##_utf8)) \
+    NAPI_STATUS_THROWS_VOID(napi_create_string_utf8(env, name, len, &name##_utf8)) \
+    NAPI_STATUS_THROWS_VOID(napi_set_named_property(env, exports, #name, name##_utf8)) \
   }
 
 #define NAPI_EXPORT_STRING(name) \


### PR DESCRIPTION
Upgrades leveldown bindings from v5.0.0-0 to v5.2.1 and napi-macros to v2.0.0.

Includes segfault fixes:
- https://github.com/Level/leveldown/pull/597
- https://github.com/Level/leveldown/pull/612
- https://github.com/Level/leveldown/pull/618
- https://github.com/Level/leveldown/pull/621

Additional fixes:
- https://github.com/Level/leveldown/pull/600
- https://github.com/Level/leveldown/pull/617
- https://github.com/Level/leveldown/pull/619
- https://github.com/Level/leveldown/pull/638
- https://github.com/Level/leveldown/pull/657

See https://github.com/Level/leveldown/issues/671