### PR TITLE
tests: fix for windows

### DIFF
--- a/test/bdb-test.js
+++ b/test/bdb-test.js
@@ -6,10 +6,12 @@
 const assert = require('bsert');
 const bdb = require('../');
 const vectors = require('./data/vectors.json');
+const os = require('os');
+const path = require('path');
 
 describe('BDB', function() {
   const num = (Math.random() * 0x100000000) >>> 0;
-  const dbpath = `/tmp/bdb-test-${num}.db`;
+  const dbpath = path.join(os.tmpdir(), `bdb-test-${num}.db`);
   const tkey = bdb.key('t', ['hash160', 'uint32']);
   const prefix = bdb.key('r');
 

--- a/test/bdb-test.js
+++ b/test/bdb-test.js
@@ -192,21 +192,20 @@ describe('BDB', function() {
             await batch.write();
             break;
         }
-
       } catch (e) {
         err = e;
       }
 
       assert(err);
       assert.equal(err.message, message);
-      await new Promise((r) => setTimeout(r, 200));
+      await new Promise(r => setTimeout(r, 200));
     }
 
     const methods = {
       'clear': 'Unsafe batch clear.',
       'put': 'Unsafe batch put.',
       'del': 'Unsafe batch del.',
-      'write': 'Unsafe batch write.',
+      'write': 'Unsafe batch write.'
     };
 
     for (const [method, message] of Object.entries(methods)) {


### PR DESCRIPTION
This PR abstracts the hardcoded `dbpath` variable such that it works on non unix operating systems like Windows. It also fixes some linting errors in the tests.

This is a precursor for my experimentation with upgrading LevelDB to the latest release. I have successfully synced bcoin using LevelDB 1.22 on Linux. I'd like to get some performance metrics before attempting to merge into `bdb`. Looking at the LevelDB issues, it appears as if some critical bugs were fixed since 1.20.

My work is here:
https://github.com/tynes/bdb/tree/leveldb-1.22

Note that the above git branch does not build on Windows yet and this PR will more easily allow me to test that it builds and operates as expected.