### PR TITLE
feat: added support for `uint64` keys

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -103,6 +103,26 @@ const types = {
       return 4;
     }
   },
+  uint64: {
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    dynamic: false,
+    size(v) {
+      return 8;
+    },
+    read(k, o) {
+      assertLen(o + 8 <= k.length);
+      return readU64BE(k, o);
+    },
+    write(k, v, o) {
+      assertType(Number.isSafeInteger(v) && v >= 0);
+      assertLen(o + 8 <= k.length);
+
+      writeU64BE(k, v, o);
+
+      return 8;
+    }
+  },
   buffer: {
     min: BUFFER_MIN,
     max: BUFFER_MAX,
@@ -583,6 +603,12 @@ function assertType(ok) {
   }
 }
 
+function readU64BE(data, off) {
+  const hi = readU32BE(data, off);
+  const lo = readU32BE(data, off + 4);
+  return hi * 0x100000000 + lo;
+}
+
 function readU32BE(data, off) {
   return (data[off++] * 0x1000000
         + data[off++] * 0x10000
@@ -592,6 +618,14 @@ function readU32BE(data, off) {
 
 function readU16BE(data, off) {
   return data[off++] * 0x100 + data[off];
+}
+
+function writeU64BE(dst, num, off) {
+  const hi = (num * (1 / 0x100000000)) | 0;
+  const lo = num | 0;
+  off = writeU32BE(dst, hi, off);
+  off = writeU32BE(dst, lo, off);
+  return off;
 }
 
 function writeU32BE(dst, num, off) {


### PR DESCRIPTION
In order to improve bcoin's coin selection and make it faster, we need to reorganize how we store UTXOs in `lib/wallet/txdb.js`. An obvious optimization is to store unspent credits separately and fetch only unspent coins. Currently, `getCredits()` in `txdb.js`, ignores all spent credits but has to iterate through all coins(both spent and unspent).

A more advanced optimization would be to select coins in some range. For example, if we want to spend 200 Satoshis, we can fetch all coins in the range of 100 to 300, for coin selection. In order to do so, we need to store coins sorted by `value`. Since bitcoin's output values are 64-bit integer values, they can not directly be stored because `bdb` doesn't support `uint64` values. 

A workaround is to use two `uint32` values. But in the long run, it will be better to add support for `uint64` as it may be required in the future for more advanced optimization.


