### PR TITLE
Add support for the async iterators

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
         run: npm i -g bslint
 
       - name: Lint
-        run: npm run lint-ci
+        run: npm run lint
 
   build:
     name: Build & Test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Database for bcoin (leveldown backend).
 
 ## Usage
 
-``` js
+```javascript
 const bdb = require('bdb');
 const db = bdb.create('/path/to/my.db');
 
@@ -39,6 +39,22 @@ await iter.each((key, value) => {
   console.log('Index: %d', index);
   console.log('Value: %s', value.toString());
 });
+
+// Async Iterator is same, just used with for await syntax.:
+// From: `rt[0000000000000000000000000000000000000000][00000000]`
+// To: `rt[ffffffffffffffffffffffffffffffffffffffff][ffffffff]`
+const asyncIter = bucket.iterator({
+  gte: myKey.min(),
+  lte: myKey.max(),
+  values: true
+});
+
+for await (const {key, value} of asyncIter) {
+  const [hash, index] = myKey.decode(key);
+  console.log('Hash: %s', hash.toString('hex'));
+  console.log('Index: %d', index);
+  console.log('Value: %s', value.toString());
+}
 
 await db.close();
 ```

--- a/bench/iter.js
+++ b/bench/iter.js
@@ -1,0 +1,417 @@
+/*!
+ * bench/iter.js - benchmark iterators.
+ *
+ * This can be run to test the performance of the iterators.
+ * We can compare old style iterators to the async iterators (generators)
+ * and see the performance hit/boost with the updated version.
+ *
+ * Usage:
+ * node ./iter.js [--iterator=<type>] [--cacheSize=<bytes>] [--location=<path>]
+ *
+ * Options:
+ * - `iterator`  This can be "each" or "async".
+ * - `cacheSize` The total number of items returned in a single next().
+ * - `location`  The location to store the db.
+ *
+ * Test cases:
+ *   - range/entriesAsync
+ *   - keys/keysAsync
+ *   - values/valuesAsync
+ *   - each/entriesAsync - delete items.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const path = require('path');
+const randomBytes = crypto.randomBytes.bind(crypto);
+const os = require('os');
+const bdb = require('..');
+
+// Key -> RANDOM_INT key
+const RANDOM_INT_REF = bdb.key('v', ['hash256']);
+
+// Key -> RANDOM_INT
+const RANDOM_INTS = bdb.key('s', ['hash256']);
+
+const num = (Math.random() * 0x100000000) >>> 0;
+const dbpath = path.join(os.tmpdir(), `bdb-bench-${num}.db`);
+
+const argConfig = {
+  'iterator': {
+    value: true,
+    valid: t => t === 'async' || t === 'each',
+    fallback: 'async'
+  },
+  'location': {
+    value: true,
+    valid: l => path.isAbsolute(l),
+    fallback: dbpath
+  },
+  'cacheSize': {
+    value: true,
+    parse: parseInt,
+    valid: a => Number.isSafeInteger(a) && a > 0,
+    fallback: 1000
+  },
+  'items': {
+    value: true,
+    parse: parseInt,
+    valid: a => Number.isSafeInteger(a) && a > 0,
+    fallback: 100000
+  }
+};
+
+(async () => {
+  let settings;
+
+  try {
+    settings = processArgs(process.argv, argConfig);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  const db = bdb.create(settings.location);
+
+  await db.open();
+
+  let batch;
+  let items = 0;
+
+  // Clean up entries
+  const iter = db.iterator({
+    gte: RANDOM_INTS.min(),
+    lte: RANDOM_INTS.max()
+  });
+
+  batch = db.batch();
+
+  console.log('Settings: ', settings);
+
+  console.log('Cleaning up database...');
+  await iter.each(async (key) => {
+    batch.del(key);
+    items++;
+  });
+
+  await batch.write();
+  console.log('Cleaned up %d items.', items);
+
+  console.log('Creating %d random entries...', settings.items);
+
+  batch = db.batch();
+
+  const randNumber = Buffer.alloc(4);
+  for (let i = 0; i < settings.items; i++) {
+    const intKey = RANDOM_INTS.encode(randomBytes(32));
+    randNumber.writeUInt32LE(i);
+    const refKey = RANDOM_INT_REF.encode(randomBytes(32));
+
+    batch.put(intKey, randNumber);
+    batch.put(refKey, intKey);
+  }
+
+  await batch.write();
+  console.log('Created %d random entries.', settings.items);
+
+  let benchIter;
+
+  if (settings.iterator === 'async') {
+    benchIter = new BenchIterAsync(db);
+  } else {
+    benchIter = new BenchIterEach(db);
+  }
+
+  console.log('Sum of all numbers: %d',
+    await benchIter.findAllNumbersAndSum());
+
+  console.log('Sum of all numbers values: %d',
+    await benchIter.rangeSum());
+
+  console.log('All keys starting with M in ref: ');
+  const keys = await benchIter.keysStartingWithM();
+  console.log(keys.slice(0, 5), '...');
+
+  await benchIter.deleteAllItems();
+
+  await db.close();
+})().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});
+
+class BenchIter {
+  constructor(db) {
+    this.db = db;
+    this.startTime = null;
+    this.endTime = null;
+    this.iterations = 0;
+    this.startMemory = null;
+    this.endMemory = null;
+  }
+
+  start() {
+    this.startTime = process.hrtime.bigint();
+    this.iterations = 0;
+  }
+
+  end() {
+    this.endTime = process.hrtime.bigint();
+
+    const ms = Number(this.endTime - this.startTime) / 1000000;
+    const rate = this.iterations / ms;
+    console.log('> Iterated %d items in %d ms.', this.iterations, ms);
+    console.log('> Rate: %d items/ms.', rate);
+    console.log('> Memory:',
+      formatMemory(memoryUsage(memoryUsage())));
+  }
+
+  async deleteAllItems() {
+    throw new Error('Not implemented.');
+  }
+}
+
+class BenchIterEach extends BenchIter {
+  async deleteAllItems() {
+    const batch = this.db.batch();
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: true
+    });
+
+    this.start();
+    await iter.each(async (key, value) => {
+      batch.del(key);
+      batch.del(value);
+      this.iterations++;
+    });
+
+    this.end();
+
+    await batch.write();
+  }
+
+  async findAllNumbersAndSum() {
+    let sum = 0;
+
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: true
+    });
+
+    this.start();
+
+    await iter.each(async (key, value) => {
+      const number = await this.db.get(value);
+      sum += number.readUInt32LE();
+      this.iterations++;
+    });
+
+    this.end();
+    return sum;
+  }
+
+  async rangeSum() {
+    let sum = 0;
+
+    const iter = this.db.iterator({
+      gte: RANDOM_INTS.min(),
+      lte: RANDOM_INTS.max(),
+      values: true
+    });
+
+    this.start();
+
+    const values = await iter.values(val => val.readUInt32LE());
+
+    for (const num of values) {
+      this.iterations++;
+      sum += num;
+    }
+
+    this.end();
+    return sum;
+  }
+
+  // This can be done effectively with proper lte/gte,
+  // but we are checking something else.
+  async keysStartingWithM() {
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: false
+    });
+
+    this.start();
+
+    const items = [];
+    await iter.keys((key) => {
+      const dec = RANDOM_INT_REF.decode(key)[0];
+
+      if (dec[0] === 77)
+        items.push(dec);
+      this.iterations++;
+    });
+
+    this.end();
+    return items;
+  }
+}
+
+class BenchIterAsync extends BenchIter {
+  async deleteAllItems() {
+    const batch = this.db.batch();
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: true
+    });
+
+    this.start();
+
+    for await (const {key, value} of iter) {
+      batch.del(key);
+      batch.del(value);
+      this.iterations++;
+    }
+
+    this.end();
+
+    await batch.write();
+  }
+
+  async findAllNumbersAndSum() {
+    let sum = 0;
+
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: true
+    });
+
+    this.start();
+
+    for await (const {value} of iter) {
+      const number = await this.db.get(value);
+      sum += number.readUInt32LE();
+      this.iterations++;
+    }
+
+    this.end();
+    return sum;
+  }
+
+  async rangeSum() {
+    let sum = 0;
+
+    const iter = this.db.iterator({
+      gte: RANDOM_INTS.min(),
+      lte: RANDOM_INTS.max(),
+      values: true
+    });
+
+    this.start();
+
+    for await (const val of iter.valuesAsync()) {
+      this.iterations++;
+      sum += val.readUInt32LE();
+    }
+
+    this.end();
+    return sum;
+  }
+
+  async keysStartingWithM() {
+    const iter = this.db.iterator({
+      gte: RANDOM_INT_REF.min(),
+      lte: RANDOM_INT_REF.max(),
+      values: false
+    });
+
+    this.start();
+
+    const items = [];
+    for await (const key of iter.keysAsync()) {
+      const dec = RANDOM_INT_REF.decode(key)[0];
+
+      if (dec[0] === 77)
+        items.push(dec);
+      this.iterations++;
+    }
+
+    this.end();
+    return items;
+  }
+}
+
+// From bcoin/bench/blockstore.js
+function processArgs(argv, config) {
+  const args = {};
+
+  for (const key in config)
+    args[key] = config[key].fallback;
+
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    const match = arg.match(/^(\-){1,2}([a-z]+)(\=)?(.*)?$/);
+
+    if (!match) {
+      throw new Error(`Unexpected argument: ${arg}.`);
+    } else {
+      const key = match[2];
+      let value = match[4];
+
+      if (!config[key])
+        throw new Error(`Invalid argument: ${arg}.`);
+
+      if (config[key].value && !value) {
+        value = process.argv[i + 1];
+        i++;
+      } else if (!config[key].value && !value) {
+        value = true;
+      } else if (!config[key].value && value) {
+        throw new Error(`Unexpected value: ${key}=${value}`);
+      }
+
+      if (config[key].parse)
+        value = config[key].parse(value);
+
+      if (value)
+        args[key] = value;
+
+      if (!config[key].valid(args[key]))
+        throw new Error(`Invalid value: ${key}=${value}`);
+    }
+  }
+
+  return args;
+}
+
+function memoryUsage() {
+  const mem = process.memoryUsage();
+
+  return {
+    total: mem.rss,
+    jsHeap: mem.heapUsed,
+    jsHeapTotal: mem.heapTotal,
+    nativeHeap: mem.rss - mem.heapTotal,
+    external: mem.external
+  };
+}
+
+function mb(num) {
+  return Math.floor(num / (1 << 20));
+}
+
+function formatMemory(raw) {
+  return {
+    total: mb(raw.total) + 'mb',
+    jsHeap: mb(raw.jsHeap) + 'mb',
+    jsHeapTotal: mb(raw.jsHeapTotal) + 'mb',
+    nativeHeap: mb(raw.nativeHeap) + 'mb',
+    external: mb(raw.external) + 'mb'
+  };
+}

--- a/bench/iter.js
+++ b/bench/iter.js
@@ -6,11 +6,11 @@
  * and see the performance hit/boost with the updated version.
  *
  * Usage:
- * node ./iter.js [--iterator=<type>] [--cacheSize=<bytes>] [--location=<path>]
+ * node ./iter.js [--iterator=<type>] [--items=<number>] [--location=<path>]
  *
  * Options:
  * - `iterator`  This can be "each" or "async".
- * - `cacheSize` The total number of items returned in a single next().
+ * - `items`     The total number of items to create.
  * - `location`  The location to store the db.
  *
  * Test cases:
@@ -47,12 +47,6 @@ const argConfig = {
     value: true,
     valid: l => path.isAbsolute(l),
     fallback: dbpath
-  },
-  'cacheSize': {
-    value: true,
-    parse: parseInt,
-    valid: a => Number.isSafeInteger(a) && a > 0,
-    fallback: 1000
   },
   'items': {
     value: true,

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const assert = require('bsert');
+const asyncIterator = Symbol.asyncIterator || 'asyncIterator';
 
 /**
  * Constants
@@ -14,6 +15,25 @@ const assert = require('bsert');
 
 const LOW = Buffer.alloc(1, 0x00);
 const HIGH = Buffer.alloc(255, 0xff);
+
+/*
+ * Iterator
+ */
+
+const ITER_TYPE_KEYS = 0;
+const ITER_TYPE_VALUES = 1;
+const ITER_TYPE_KEY_VAL = 2;
+
+/**
+ * Iteration types.
+ * @enum {Number}
+ */
+
+const iteratorTypes = {
+  ITER_TYPE_KEYS,
+  ITER_TYPE_VALUES,
+  ITER_TYPE_KEY_VAL
+};
 
 /**
  * DB
@@ -508,6 +528,82 @@ class DB {
     return iter.values(options.parse);
   }
 
+  /*
+   * Async iterators
+   */
+
+  /**
+   * Get generator for all the keys from iterator options.
+   * @param {Object} options - Iterator Options.
+   * @returns {AsyncIterator}
+   */
+
+  entriesAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: true,
+      values: true
+    });
+
+    return iter.entriesAsync();
+  }
+
+  /**
+   * Get generator for all keys from iterator options.
+   * @param {Object} options - Iterator options.
+   * @returns {AsyncIterator}
+   */
+
+  keysAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: true,
+      values: false
+    });
+
+    return iter.keysAsync();
+  }
+
+  /**
+   * Get generator for all keys from iterator options.
+   * @param {Object} options - Iterator options.
+   * @returns {AsyncIterator}
+   */
+
+  valuesAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: false,
+      values: true
+    });
+
+    return iter.valuesAsync();
+  }
+
   /**
    * Dump database (for debugging).
    * @returns {Promise} - Returns Object.
@@ -904,6 +1000,78 @@ class Bucket {
 
     return iter.values(options.parse);
   }
+
+  /**
+   * Get generator for all keys from iterator options.
+   * @param {Object} options - Iterator options.
+   * @returns {AsyncIterator}
+   */
+
+  entriesAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: true,
+      values: true
+    });
+
+    return iter.entriesAsync();
+  }
+
+  /**
+   * Get generator for all keys from iterator options.
+   * @param {Object} options - Iterator options.
+   * @returns {AsyncIterator}
+   */
+
+  keysAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: true,
+      values: false
+    });
+
+    return iter.keysAsync();
+  }
+
+  /**
+   * Get generator for all keys from iterator options.
+   * @param {Object} options - Iterator options.
+   * @returns {AsyncIterator}
+   */
+
+  valuesAsync(options) {
+    if (options == null)
+      options = {};
+
+    const iter = this.iterator({
+      gt: options.gt,
+      lt: options.lt,
+      gte: options.gte,
+      lte: options.lte,
+      limit: options.limit,
+      reverse: options.reverse,
+      keys: false,
+      values: true
+    });
+
+    return iter.valuesAsync();
+  }
 }
 
 /**
@@ -1244,6 +1412,114 @@ class Iterator {
     });
 
     return items;
+  }
+
+  /**
+   * Collect all keys from iterator.
+   * @returns {AsyncIterator}
+   */
+
+  keysAsync() {
+    return new AsyncIterator(this, iteratorTypes.ITER_TYPE_KEYS);
+  }
+
+  /**
+   * Collect all values from iterator.
+   * @returns {AsyncIterator}
+   */
+
+  valuesAsync() {
+    return new AsyncIterator(this, iteratorTypes.ITER_TYPE_VALUES);
+  }
+
+  /**
+   * Collect all
+   * @returns {AsyncIterator}
+   */
+
+  entriesAsync() {
+    return new AsyncIterator(this, iteratorTypes.ITER_TYPE_KEY_VAL);
+  }
+
+  /**
+   * Default iterator collects all
+   * @returns {AsyncIterator}
+   */
+
+  [asyncIterator]() {
+    return this.entriesAsync();
+  }
+}
+
+/**
+ * Async iterator.
+ */
+
+class AsyncIterator {
+  /** @type {Iterator} iter */
+  iter;
+
+  /** @type {iteratorTypes} type */
+  type;
+
+  /**
+   * @param {Iterator} iter
+   * @param {iteratorTypes} type
+   */
+
+  constructor(iter, type) {
+    this.iter = iter;
+    this.type = type;
+  }
+
+  get finished() {
+    return this.iter.finished;
+  }
+
+  async next() {
+    if (!await this.iter.next())
+      return { value: undefined, done: true };
+
+    const key = this.iter.key;
+    const value = this.iter.value;
+
+    switch (this.type) {
+      case ITER_TYPE_KEYS:
+        return { value: key, done: false };
+      case ITER_TYPE_VALUES:
+        return { value: value, done: false };
+      case ITER_TYPE_KEY_VAL: {
+        const item = new IteratorItem(key, value);
+        return { value: item, done: false };
+      }
+      default:
+        throw new Error('Bad value mode.');
+    }
+  }
+
+  async return(value) {
+    const result = {
+      value: value ? value : undefined,
+      done: true
+    };
+
+    await this.iter.end();
+
+    return result;
+  }
+
+  async throw(err) {
+    try {
+      await this.iter.end();
+    } catch (e) {
+      ;
+    }
+
+    return Promise.reject(err);
+  }
+
+  [asyncIterator]() {
+    return this;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,16 +17,15 @@
   "main": "./lib/bdb.js",
   "scripts": {
     "install": "node-gyp rebuild",
-    "lint": "eslint lib/ test/ || exit 0",
-    "lint-ci": "eslint lib/ test/",
+    "lint": "eslint lib/ test/",
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
-    "bsert": "~0.0.10",
+    "bsert": "~0.0.12",
     "loady": "~0.0.5"
   },
   "devDependencies": {
-    "bmocha": "^2.1.0"
+    "bmocha": "^2.1.8"
   },
   "engines": {
     "node": ">=8.6.0"

--- a/test/bdb-test.js
+++ b/test/bdb-test.js
@@ -335,6 +335,30 @@ describe('BDB', function() {
       assert.strictEqual(values[0].toString('hex'), vectors[0].value);
       assert.strictEqual(valuesIter.finished, true);
     });
+
+    it('should pass iterator to fn', async () => {
+      const valuesIter = bucket.valuesAsync({
+        gte: nkey.min(),
+        lte: nkey.max()
+      });
+
+      const filter = async function*(iter) {
+        for await (const item of iter) {
+          if (item[0] === 0x8b)
+            yield item;
+
+          continue;
+        }
+      };
+
+      const values = [];
+
+      for await (const value of filter(valuesIter))
+        values.push(value);
+
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0][0], 0x8b);
+    });
   });
 
   describe('thread safety', function() {

--- a/test/bdb-test.js
+++ b/test/bdb-test.js
@@ -87,7 +87,42 @@ describe('BDB', function() {
       total++;
     });
 
-    assert.equal(total, 3);
+    assert.equal(total, vectors.length);
+  });
+
+  it('iterate over keys and values in a bucket (async)', async () => {
+    const mkey = bdb.key('m', ['hash160', 'uint32']);
+
+    const bucket = db.bucket(prefix.encode());
+
+    const batch = bucket.batch();
+
+    for (let i = 0; i < vectors.length; i++) {
+      const vector = vectors[i];
+      const key = mkey.encode(Buffer.from(vector.key[0], 'hex'), vector.key[1]);
+      const value = Buffer.from(vector.value, 'hex');
+      batch.put(key, value);
+    }
+
+    await batch.write();
+
+    const iter = bucket.iterator({
+      gte: mkey.min(),
+      lte: mkey.max(),
+      values: true
+    });
+
+    let total = 0;
+
+    for await (const {key, value} of iter) {
+      const [hash, index] = mkey.decode(key);
+      assert.equal(hash.toString('hex'), vectors[total].key[0]);
+      assert.equal(index, vectors[total].key[1]);
+      assert.equal(value.toString('hex'), vectors[total].value);
+      total++;
+    }
+
+    assert.equal(total, vectors.length);
   });
 
   it('delete key and value', async () => {
@@ -136,7 +171,7 @@ describe('BDB', function() {
         lte: nkey.max()
       });
 
-      assert.equal(keys.length, 3);
+      assert.equal(keys.length, vectors.length);
 
       for (let i = 0; i < keys.length; i++) {
         const [hash, index] = nkey.decode(keys[i]);
@@ -152,7 +187,7 @@ describe('BDB', function() {
         reverse: true
       });
 
-      assert.equal(keys.length, 3);
+      assert.equal(keys.length, vectors.length);
 
       keys.reverse();
 
@@ -161,6 +196,144 @@ describe('BDB', function() {
         assert.equal(hash.toString('hex'), vectors[i].key[0]);
         assert.equal(index, vectors[i].key[1]);
       }
+    });
+  });
+
+  describe('Async Iterator', function() {
+    let nkey, bucket = null;
+
+    before(async () => {
+      nkey = bdb.key('n', ['hash160', 'uint32']);
+      bucket = db.bucket(prefix.encode());
+
+      const batch = bucket.batch();
+
+      for (let i = 0; i < vectors.length; i++) {
+        const vector = vectors[i];
+
+        const key = nkey.encode(Buffer.from(vector.key[0], 'hex'),
+                                vector.key[1]);
+
+        const value = Buffer.from(vector.value, 'hex');
+
+        batch.put(key, value);
+      }
+
+      await batch.write();
+    });
+
+    it('in standard order', async () => {
+      const keysIter = bucket.keysAsync({
+        gte: nkey.min(),
+        lte: nkey.max()
+      });
+
+      const keys = [];
+
+      for await (const key of keysIter)
+        keys.push(key);
+
+      assert.equal(keys.length, vectors.length);
+
+      for (let i = 0; i < keys.length; i++) {
+        const [hash, index] = nkey.decode(keys[i]);
+        assert.equal(hash.toString('hex'), vectors[i].key[0]);
+        assert.equal(index, vectors[i].key[1]);
+      }
+    });
+
+    it('in reverse order', async () => {
+      const keysIter = bucket.keysAsync({
+        gte: nkey.min(),
+        lte: nkey.max(),
+        reverse: true
+      });
+
+      const keys = [];
+
+      for await (const key of keysIter)
+        keys.push(key);
+
+      assert.equal(keys.length, vectors.length);
+
+      keys.reverse();
+
+      for (let i = 0; i < keys.length; i++) {
+        const [hash, index] = nkey.decode(keys[i]);
+        assert.equal(hash.toString('hex'), vectors[i].key[0]);
+        assert.equal(index, vectors[i].key[1]);
+      }
+    });
+
+    it('should break and close iterator', async () => {
+      const valuesIter = bucket.valuesAsync({
+        gte: nkey.min(),
+        lte: nkey.max()
+      });
+
+      const values = [];
+
+      for await (const value of valuesIter) {
+        values.push(value);
+        break;
+      }
+
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0].toString('hex'), vectors[0].value);
+      assert.strictEqual(valuesIter.finished, true);
+    });
+
+    it('should return and close iterator', async () => {
+      const valuesIter = bucket.valuesAsync({
+        gte: nkey.min(),
+        lte: nkey.max()
+      });
+
+      const values = [];
+
+      const fn = async () => {
+        for await (const value of valuesIter) {
+          values.push(value);
+          return;
+        }
+      };
+
+      await fn();
+
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0].toString('hex'), vectors[0].value);
+      assert.strictEqual(valuesIter.finished, true);
+    });
+
+    it('should throw and close iterator', async () => {
+      const msg = 'Error at some point.';
+      const valuesIter = bucket.valuesAsync({
+        gte: nkey.min(),
+        lte: nkey.max()
+      });
+
+      const values = [];
+
+      const fn = async () => {
+        for await (const value of valuesIter) {
+          values.push(value);
+          throw new Error(msg);
+        }
+      };
+
+      let err;
+      try {
+        await fn();
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err);
+      assert.strictEqual(err.message, msg);
+
+      assert.strictEqual(values.length, 1);
+      assert.strictEqual(values[0].toString('hex'), vectors[0].value);
+      assert.strictEqual(valuesIter.finished, true);
     });
   });
 


### PR DESCRIPTION
Current implementation of the iterators is not flexible. There are `each`, `range`, `keys` and `values`. 
`range`, `keys` and `values` - all accumulate the results and return it like that. Given the use cases in the bcoin and hsd - this is never a good idea. Some entries in db if they can't be range filtered (gte/lte) properly and used w/o limits can result in huge memory usage and also double processing in most of them time (stored in array -> filter/modify -> etc.).

`each` allows to work on each while they are received from the database, but it's mostly still accumulated as you would need to setup callback chain in order to use it properly.

This implementation of the iterators instead uses `for await ()` which allows for the chaining database results to the codebase. Instead of consuming the data from db at once and constructing array to use, we can chain asyng generators if we want to have transformations which can reduce the amount of information we store in memory.

Iterators, DB and bucket now have additional methods for the async generators:
  - entriesAsync - returns an async iterator that yields IteratorItems with .key and .value
  - valuesAsync - return an async iterator that yields values. NOTE: This needs `values: true` in the iterator configs.
  - keysAsync - return an async iterator that yields keys.

Examples:

Best translation of this concept is using each:

```js
await iter.each(async (key, value) => {
      //work with key/values
});
```

Which can be now written as:
```js
for await (const {key, value} of iter) {
   // work with key/values
}
```

In case where we want to chain multiple calls it becomes more complicated than just using `array`s, but as I mentioned above - accumulating arrays first comes with huge cost for the big queries.


Example of chaining these calls:

```js
const filter = async function*(iter) {
  for await (const item of iter) {
    if (item[0] === 0x8b)
      yield item;

    continue;
  }
};

const values = [];

for await (const value of filter(valuesIter))
  values.push(value);
```