### PR TITLE
pkg: change exports.

### DIFF
--- a/lib/bdb.js
+++ b/lib/bdb.js
@@ -7,13 +7,30 @@
 'use strict';
 
 const assert = require('bsert');
-const DB = require('./db');
-const Key = require('./key');
-const MemDB = require('./memdb');
-const Level = require('./level');
+const {DB} = require('./db');
+const {Key} = require('./key');
+const {MemDB} = require('./memdb');
+const {Level} = require('./level');
 
 exports.DB = DB;
 exports.Key = Key;
+
+/**
+ * Create a database.
+ * @param {Object} [options={}]
+ * @property {String} [options.location] - Database location.
+ * @property {Boolean} [options.memory=false] - Use an in-memory database.
+ * @property {Boolean} [options.createIfMissing=true] - Create database if it
+ * does not exist.
+ * @property {Boolean} [options.errorIfExists=false] - Error on open if
+ * database exists.
+ * @property {Boolean} [options.compression=true] - Enable snappy compression.
+ * @property {Number} [options.cacheSize=8 << 20] - LRU cache and write buffer
+ * size.
+ * @property {Number} [options.maxFiles=64] - Maximum open files.
+ * @property {Number} [options.maxFileSize=2 << 20] - Maximum file size.
+ * @returns {DB}
+ */
 
 exports.create = (options) => {
   if (options == null)
@@ -35,4 +52,10 @@ exports.create = (options) => {
   return new DB(Level, location, options);
 };
 
-exports.key = (id, args) => new Key(id, args);
+/**
+ * @param {Number|String} id
+ * @param {String[]|null} [ops=[]]
+ * @returns {Key}
+ */
+
+exports.key = (id, ops) => new Key(id, ops);

--- a/lib/db.js
+++ b/lib/db.js
@@ -35,8 +35,8 @@ const iteratorTypes = {
   ITER_TYPE_KEY_VAL
 };
 
-/** @typedef {import('./memdb')} MemDB */
-/** @typedef {import('./level')} LevelDB */
+/** @typedef {import('./memdb').MemDB} MemDB */
+/** @typedef {import('./level').Level} Level */
 
 /**
  * @typedef {Object} MemDBClass
@@ -148,7 +148,7 @@ class DB {
   /** @type {boolean} */
   leveldown;
 
-  /** @type {LevelDB|MemDB} */
+  /** @type {Level|MemDB} */
   binding;
 
   /**
@@ -1762,12 +1762,6 @@ class DBOptions {
       this.maxFileSize = options.maxFileSize;
     }
 
-    if (options.paranoidChecks != null) {
-      assert(typeof options.paranoidChecks === 'boolean',
-        '`paranoidChecks` must be a boolean.');
-      this.paranoidChecks = options.paranoidChecks;
-    }
-
     if (options.memory != null) {
       assert(typeof options.memory === 'boolean',
         '`memory` must be a boolean.');
@@ -1971,4 +1965,4 @@ function versionError(name) {
  * Expose
  */
 
-module.exports = DB;
+exports.DB = DB;

--- a/lib/key.js
+++ b/lib/key.js
@@ -649,4 +649,4 @@ function writeU16BE(dst, num, off) {
  * Expose
  */
 
-module.exports = Key;
+exports.Key = Key;

--- a/lib/level-browser.js
+++ b/lib/level-browser.js
@@ -722,4 +722,4 @@ function createErrback(callback) {
  * Expose
  */
 
-module.exports = Level;
+exports.Level = Level;

--- a/lib/level.js
+++ b/lib/level.js
@@ -220,4 +220,4 @@ function isValue(key) {
  * Expose
  */
 
-module.exports = LevelDOWN;
+exports.Level = LevelDOWN;

--- a/lib/memdb.js
+++ b/lib/memdb.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const assert = require('bsert');
-const RBT = require('./rbt');
+const {RBT} = require('./rbt');
 const DUMMY = Buffer.alloc(0);
 
 /** @typedef {import('./rbt').RBTData} RBTData */
@@ -670,4 +670,4 @@ function cmp(a, b) {
  * Expose
  */
 
-module.exports = MemDB;
+exports.MemDB = MemDB;

--- a/lib/rbt.js
+++ b/lib/rbt.js
@@ -963,5 +963,5 @@ function copyRight(parent, node) {
  * Expose
  */
 
-RBT.RBTData = RBTData;
-module.exports = RBT;
+exports.RBTData = RBTData;
+exports.RBT = RBT;


### PR DESCRIPTION
Deprecate usage of `module.exports` as export.