### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
@@ -33,11 +33,15 @@ jobs:
         exclude:
           - os: windows-latest
             node: 14.x
+          - os: macos-latest
+            node: 14.x
+          - os: macos-latest
+            node: 16.x
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js ${{matrix.node}}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node}}
 


### PR DESCRIPTION
Remove macos v14/v16 tests. (gh actions are failing to install nodejs)

Update checkout/node-setup actions.