### PR TITLE
Add support for multi-byte keys.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -852,6 +852,7 @@ class Batch {
 
   /**
    * Get bucket.
+   * @param {Buffer} prefix
    * @returns {Batch}
    */
 
@@ -1907,6 +1908,12 @@ function wrap(resolve, reject) {
   };
 }
 
+/**
+ * @param {Buffer|null} prefix
+ * @param {Buffer|null} key
+ * @returns {Buffer?}
+ */
+
 function slice(prefix, key) {
   if (key == null)
     return key;
@@ -1924,6 +1931,12 @@ function slice(prefix, key) {
 
   return key.slice(prefix.length);
 }
+
+/**
+ * @param {Buffer} prefix
+ * @param {Buffer} key
+ * @returns {Buffer}
+ */
 
 function concat(prefix, key) {
   assert(Buffer.isBuffer(key), 'Key must be a buffer.');

--- a/lib/key.js
+++ b/lib/key.js
@@ -575,11 +575,10 @@ class Key {
  */
 
 function makeID(id) {
-  if (typeof id === 'string') {
-    assert(id.length === 1);
+  if (typeof id === 'string')
     id =  Buffer.from(id, 'ascii');
-  }
 
+  // Number is not supported for multi-byte ids.
   if (typeof id === 'number') {
     assert((id & 0xff) === id);
     assert(id !== 0xff);

--- a/lib/key.js
+++ b/lib/key.js
@@ -370,14 +370,15 @@ class BaseKey {
   }
 
   /**
+   * @param {Buffer} id
    * @param {Array} args
    * @returns {Number}
    */
 
-  getSize(args) {
+  getSize(id, args) {
     assert(args.length === this.ops.length);
 
-    let size = 1 + this.size;
+    let size = id.length + this.size;
 
     if (this.index === -1)
       return size;
@@ -394,7 +395,7 @@ class BaseKey {
   }
 
   /**
-   * @param {Number} id
+   * @param {Buffer} id
    * @param {Array} args
    * @returns {Buffer}
    */
@@ -405,12 +406,12 @@ class BaseKey {
     if (args.length !== this.ops.length)
       throw new Error('Wrong number of arguments passed to key.');
 
-    const size = this.getSize(args);
+    const size = this.getSize(id, args);
     const key = Buffer.allocUnsafe(size);
 
-    key[0] = id;
+    id.copy(key);
 
-    let offset = 1;
+    let offset = id.length;
 
     for (let i = 0; i < this.ops.length; i++) {
       const op = this.ops[i];
@@ -423,7 +424,7 @@ class BaseKey {
   }
 
   /**
-   * @param {Number} id
+   * @param {Buffer} id
    * @param {Buffer} key
    * @returns {Array}
    */
@@ -434,12 +435,12 @@ class BaseKey {
     if (this.ops.length === 0)
       return [];
 
-    if (key.length === 0 || key[0] !== id)
+    if (!prefixMatches(id, key))
       throw new Error('Key prefix mismatch.');
 
     const args = [];
 
-    let offset = 1;
+    let offset = id.length;
 
     for (const op of this.ops) {
       const arg = op.read(key, offset);
@@ -453,7 +454,7 @@ class BaseKey {
   }
 
   /**
-   * @param {Number} id
+   * @param {Buffer} id
    * @param {Array} args
    * @returns {Buffer}
    */
@@ -469,7 +470,7 @@ class BaseKey {
   }
 
   /**
-   * @param {Number} id
+   * @param {Buffer} id
    * @param {Array} args
    * @returns {Buffer}
    */
@@ -485,15 +486,13 @@ class BaseKey {
   }
 
   /**
-   * @param {Number} id
+   * @param {Buffer} id
    * @returns {Buffer}
    */
 
   root(id) {
-    const key = Buffer.allocUnsafe(1);
-
-    key[0] = id;
-
+    const key = Buffer.allocUnsafe(id.length);
+    id.copy(key);
     return key;
   }
 }
@@ -514,7 +513,7 @@ class Key {
   constructor(id, ops = []) {
     assert(Array.isArray(ops));
 
-    /** @type {Number} */
+    /** @type {Buffer} */
     this.id = makeID(id);
 
     /** @type {BaseKey} */
@@ -571,20 +570,41 @@ class Key {
  */
 
 /**
- * @param {Number|String} id
- * @returns {Number}
+ * @param {Number|String|Buffer} id
+ * @returns {Buffer}
  */
 
 function makeID(id) {
   if (typeof id === 'string') {
     assert(id.length === 1);
-    id = id.charCodeAt(0);
+    id =  Buffer.from(id, 'ascii');
   }
 
-  assert((id & 0xff) === id);
-  assert(id !== 0xff);
+  if (typeof id === 'number') {
+    assert((id & 0xff) === id);
+    assert(id !== 0xff);
 
+    id =  Buffer.from([id]);
+  }
+
+  assert(Buffer.isBuffer(id));
   return id;
+}
+
+/**
+ * @param {Buffer} id
+ * @param {Buffer} key
+ * @returns {Boolean}
+ */
+
+function prefixMatches(id, key) {
+  if (key.length === 0)
+    return false;
+
+  if (key.length < id.length)
+    return false;
+
+  return key.slice(0, id.length).equals(id);
 }
 
 /**

--- a/lib/key.js
+++ b/lib/key.js
@@ -303,7 +303,6 @@ const types = {
 
 /**
  * BaseKey
- * @ignore
  */
 
 class BaseKey {
@@ -323,6 +322,11 @@ class BaseKey {
     this.init(ops);
   }
 
+  /**
+   * @param {String[]} [ops]
+   * @returns {BaseKey}
+   */
+
   static create(ops) {
     const hash = ops ? ops.join(':') : '';
     const cache = keyCache[hash];
@@ -336,6 +340,11 @@ class BaseKey {
 
     return key;
   }
+
+  /**
+   * @param {String[]} ops
+   * @returns {void}
+   */
 
   init(ops) {
     for (let i = 0; i < ops.length; i++) {
@@ -360,6 +369,11 @@ class BaseKey {
     }
   }
 
+  /**
+   * @param {Array} args
+   * @returns {Number}
+   */
+
   getSize(args) {
     assert(args.length === this.ops.length);
 
@@ -378,6 +392,12 @@ class BaseKey {
 
     return size;
   }
+
+  /**
+   * @param {Number} id
+   * @param {Array} args
+   * @returns {Buffer}
+   */
 
   encode(id, args) {
     assert(Array.isArray(args));
@@ -402,11 +422,17 @@ class BaseKey {
     return key;
   }
 
+  /**
+   * @param {Number} id
+   * @param {Buffer} key
+   * @returns {Array}
+   */
+
   decode(id, key) {
     assert(Buffer.isBuffer(key));
 
     if (this.ops.length === 0)
-      return key;
+      return [];
 
     if (key.length === 0 || key[0] !== id)
       throw new Error('Key prefix mismatch.');
@@ -426,6 +452,12 @@ class BaseKey {
     return args;
   }
 
+  /**
+   * @param {Number} id
+   * @param {Array} args
+   * @returns {Buffer}
+   */
+
   min(id, args) {
     for (let i = args.length; i < this.ops.length; i++) {
       const op = this.ops[i];
@@ -436,6 +468,12 @@ class BaseKey {
     return this.encode(id, args);
   }
 
+  /**
+   * @param {Number} id
+   * @param {Array} args
+   * @returns {Buffer}
+   */
+
   max(id, args) {
     for (let i = args.length; i < this.ops.length; i++) {
       const op = this.ops[i];
@@ -445,6 +483,11 @@ class BaseKey {
 
     return this.encode(id, args);
   }
+
+  /**
+   * @param {Number} id
+   * @returns {Buffer}
+   */
 
   root(id) {
     const key = Buffer.allocUnsafe(1);
@@ -471,25 +514,52 @@ class Key {
   constructor(id, ops = []) {
     assert(Array.isArray(ops));
 
+    /** @type {Number} */
     this.id = makeID(id);
+
+    /** @type {BaseKey} */
     this.base = BaseKey.create(ops);
   }
+
+  /**
+   * @param {Array} args
+   * @returns {Buffer}
+   */
 
   encode(...args) {
     return this.base.encode(this.id, args);
   }
 
+  /**
+   * @param {Buffer} key
+   * @returns {Array}
+   */
+
   decode(key) {
     return this.base.decode(this.id, key);
   }
+
+  /**
+   * @param {Array} args
+   * @returns {Buffer}
+   */
 
   min(...args) {
     return this.base.min(this.id, args);
   }
 
+  /**
+   * @param {Array} args
+   * @returns {Buffer}
+   */
+
   max(...args) {
     return this.base.max(this.id, args);
   }
+
+  /**
+   * @returns {Buffer}
+   */
 
   root() {
     return this.base.root(this.id);
@@ -498,6 +568,11 @@ class Key {
 
 /*
  * Helpers
+ */
+
+/**
+ * @param {Number|String} id
+ * @returns {Number}
  */
 
 function makeID(id) {
@@ -512,10 +587,23 @@ function makeID(id) {
   return id;
 }
 
+/**
+ * @param {String} v
+ * @param {BufferEncoding} [enc]
+ * @returns {Number}
+ */
+
 function sizeString(v, enc) {
   assertType(typeof v === 'string');
   return 1 + Buffer.byteLength(v, enc);
 }
+
+/**
+ * @param {Buffer} k
+ * @param {Number} o
+ * @param {BufferEncoding} [enc]
+ * @returns {String}
+ */
 
 function readString(k, o, enc) {
   assertLen(o + 1 <= k.length);
@@ -523,6 +611,14 @@ function readString(k, o, enc) {
 
   return k.toString(enc, o + 1, o + 1 + k[o]);
 }
+
+/**
+ * @param {Buffer} k
+ * @param {String} v
+ * @param {Number} o
+ * @param {BufferEncoding} [enc]
+ * @returns {Number}
+ */
 
 function writeString(k, v, o, enc) {
   assertType(typeof v === 'string');
@@ -540,10 +636,21 @@ function writeString(k, v, o, enc) {
   return 1 + size;
 }
 
+/**
+ * @param {Buffer} v
+ * @returns {Number}
+ */
+
 function sizeBuffer(v) {
   assertType(Buffer.isBuffer(v));
   return 1 + v.length;
 }
+
+/**
+ * @param {Buffer} k
+ * @param {Number} o
+ * @returns {Buffer}
+ */
 
 function readBuffer(k, o) {
   assertLen(o + 1 <= k.length);
@@ -552,7 +659,14 @@ function readBuffer(k, o) {
   return k.slice(o + 1, o + 1 + k[o]);
 }
 
-function writeBuffer(k, v, o, enc) {
+/**
+ * @param {Buffer} k
+ * @param {Buffer} v
+ * @param {Number} o
+ * @returns {Number}
+ */
+
+function writeBuffer(k, v, o) {
   assertType(Buffer.isBuffer(v));
   assertLen(v.length <= 255);
   assertLen(o + 1 <= k.length);
@@ -564,6 +678,11 @@ function writeBuffer(k, v, o, enc) {
   return 1 + v.length;
 }
 
+/**
+ * @param {Buffer|String} data
+ * @returns {Number}
+ */
+
 function sizeHex(data) {
   if (Buffer.isBuffer(data))
     return data.length;
@@ -572,6 +691,13 @@ function sizeHex(data) {
 
   return data.length >>> 1;
 }
+
+/**
+ * @param {Buffer} data
+ * @param {String} str
+ * @param {Number} off
+ * @returns {Number}
+ */
 
 function writeHex(data, str, off) {
   if (Buffer.isBuffer(str))

--- a/test/key-test.js
+++ b/test/key-test.js
@@ -21,6 +21,16 @@ const KEY_IDS = [{
   num: 0x7a, // 'z'
   buf: Buffer.from('z', 'ascii'),
   expected: Buffer.from('z', 'ascii')
+}, {
+  str: 'aa',
+  num: null, // does not support.
+  buf: Buffer.from('aa', 'ascii'),
+  expected: Buffer.from('aa', 'ascii')
+}, {
+  str: 'abcd',
+  num: null, // does not support.
+  buf: Buffer.from('abcd', 'ascii'),
+  expected: Buffer.from('abcd', 'ascii')
 }];
 
 const KEY_OPS = [{
@@ -69,6 +79,11 @@ describe('Key', function() {
     });
 
     it(`should create key for ${KEY_ID.str} (num)`, () => {
+      if (KEY_ID.num == null) {
+        this.skip();
+        return;
+      }
+
       const key = bdb.key(KEY_ID.num);
 
       assert.bufferEqual(key.encode(), KEY_ID.expected);

--- a/test/key-test.js
+++ b/test/key-test.js
@@ -78,7 +78,7 @@ describe('Key', function() {
       assert.bufferEqual(key.root(), KEY_ID.buf);
     });
 
-    it.skip(`should create key for ${KEY_ID.str} (buf)`, () => {
+    it(`should create key for ${KEY_ID.str} (buf)`, () => {
       const key = bdb.key(KEY_ID.buf);
 
       assert.bufferEqual(key.encode(), KEY_ID.expected);

--- a/test/key-test.js
+++ b/test/key-test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const assert = require('bsert');
+const bdb = require('..');
+
+const BUFFER_MIN = Buffer.alloc(0);
+const BUFFER_MAX = Buffer.alloc(255, 0xff);
+
+const KEY_IDS = [{
+  str: 'a',
+  num: 0x61, // 'a'
+  buf: Buffer.from('a', 'ascii'),
+  expected: Buffer.from('a', 'ascii')
+}, {
+  str: 'A',
+  num: 0x41, // 'A'
+  buf: Buffer.from('A', 'ascii'),
+  expected: Buffer.from('A', 'ascii')
+}, {
+  str: 'z',
+  num: 0x7a, // 'z'
+  buf: Buffer.from('z', 'ascii'),
+  expected: Buffer.from('z', 'ascii')
+}];
+
+const KEY_OPS = [{
+  ops: [],
+  values: [],
+  expected: Buffer.alloc(0),
+  mins: [],
+  expectedMins: Buffer.alloc(0),
+  maxes: [],
+  expectedMaxes: Buffer.alloc(0)
+}, {
+  ops: ['uint32'],
+  values: [0xdeadbeef],
+  expected: Buffer.from('deadbeef', 'hex'),
+  mins: [0x0],
+  expectedMins: Buffer.from('00000000', 'hex'),
+  maxes: [0xffffffff],
+  expectedMaxes: Buffer.from('ffffffff', 'hex')
+}, {
+  ops: ['char', 'uint16', 'buffer'],
+  values: ['c', 0xdead, Buffer.from('beef', 'hex')],
+  expected: Buffer.from('63dead02beef', 'hex'),
+  mins: ['\x00', 0x0, BUFFER_MIN],
+  expectedMins: Buffer.concat([
+    Buffer.from('000000', 'hex'),
+    Buffer.from([0]) // length of the buffer.
+  ]),
+  maxes: ['\xff', 0xffff, BUFFER_MAX],
+  expectedMaxes: Buffer.concat([
+    Buffer.from('ffffff', 'hex'),
+    Buffer.from([BUFFER_MAX.length]),
+    BUFFER_MAX
+  ])
+}];
+
+describe('Key', function() {
+  for (const KEY_ID of KEY_IDS) {
+    it(`should create key for ${KEY_ID.str} (str)`, () => {
+      const key = bdb.key(KEY_ID.str);
+
+      assert.bufferEqual(key.encode(), KEY_ID.expected);
+      assert.bufferEqual(key.min(), KEY_ID.expected);
+      assert.bufferEqual(key.max(), KEY_ID.expected);
+      assert.deepStrictEqual(key.decode(KEY_ID.expected), []);
+      assert.bufferEqual(key.root(), KEY_ID.buf);
+    });
+
+    it(`should create key for ${KEY_ID.str} (num)`, () => {
+      const key = bdb.key(KEY_ID.num);
+
+      assert.bufferEqual(key.encode(), KEY_ID.expected);
+      assert.bufferEqual(key.min(), KEY_ID.expected);
+      assert.bufferEqual(key.max(), KEY_ID.expected);
+      assert.deepStrictEqual(key.decode(KEY_ID.expected), []);
+      assert.bufferEqual(key.root(), KEY_ID.buf);
+    });
+
+    it.skip(`should create key for ${KEY_ID.str} (buf)`, () => {
+      const key = bdb.key(KEY_ID.buf);
+
+      assert.bufferEqual(key.encode(), KEY_ID.expected);
+      assert.bufferEqual(key.min(), KEY_ID.expected);
+      assert.bufferEqual(key.max(), KEY_ID.expected);
+      assert.deepStrictEqual(key.decode(KEY_ID.expected), []);
+      assert.bufferEqual(key.root(), KEY_ID.buf);
+    });
+
+    for (const KEY_OP of KEY_OPS) {
+      const key = bdb.key(KEY_ID.str, KEY_OP.ops);
+
+      it(`should encode ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const encoded = key.encode(...KEY_OP.values);
+        const expected = Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expected
+        ]);
+
+        assert.bufferEqual(encoded, expected);
+      });
+
+      it(`should get max for ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const max = key.max();
+        const expected = Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expectedMaxes
+        ]);
+
+        assert.bufferEqual(max, expected);
+      });
+
+      it(`should get min for ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const min = key.min();
+        const expected = Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expectedMins
+        ]);
+
+        assert.bufferEqual(min, expected);
+      });
+
+      it(`should get root for ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const root = key.root();
+        assert.bufferEqual(root, KEY_ID.buf);
+      });
+
+      it(`should decode ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const decoded = key.decode(Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expected
+        ]));
+
+        assert.deepStrictEqual(decoded, KEY_OP.values);
+      });
+
+      it(`should decode min for ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const decodedMin = key.decode(Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expectedMins
+        ]));
+
+        assert.deepStrictEqual(decodedMin, KEY_OP.mins);
+      });
+
+      it(`should decode max for ${KEY_ID.str} with ops ${KEY_OP.ops}`, () => {
+        const decodedMax = key.decode(Buffer.concat([
+          KEY_ID.expected,
+          KEY_OP.expectedMaxes
+        ]));
+
+        assert.deepStrictEqual(decodedMax, KEY_OP.maxes);
+      });
+    }
+  }
+});


### PR DESCRIPTION
BDB keys now support multi-byte keys. Adds support for Buffers as keys. All keys internally they will be represented as bytes, instead of numbers.

  - Add buffer support: `bdb.key(Buffer.from([1,2,3]))`
  - Add multi char string support: `bdb.key('abc')`

NOTE: Number is not supported for multi-byte keys. (We could potentially add number -> buffer and BigInt -> buffer, but better use buffers in this case)