### PR TITLE
bdb: expose more db types.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1984,4 +1984,12 @@ function versionError(name) {
  * Expose
  */
 
+DB.Batch = Batch;
+DB.Bucket = Bucket;
+DB.Iterator = Iterator;
+DB.AsyncIterator = AsyncIterator;
+DB.DBOptions = DBOptions;
+DB.IteratorItem = IteratorItem;
+DB.IteratorOptions = IteratorOptions;
+
 module.exports = DB;


### PR DESCRIPTION
This allows db consumers to use Batch/Iterator/etc. to use these types as args in typedefs.

e.g.

```js
/** @typedef {import('bdb').DB.Batch} Batch */

class AbstractMigration {
  ....
  /**
   * Run the actual migration
   * @param {Batch} batch
   * @returns {Promise}
   */

  async migrate(batch) {
    throw new Error('Abstract method.');
  }
}