### PR TITLE
Call end once async iteration is done.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1349,7 +1349,6 @@ class Iterator {
     }
 
     assert(this.finished);
-
     this.cleanup();
 
     return false;
@@ -1613,6 +1612,7 @@ class AsyncIterator {
   constructor(iter, type) {
     this.iter = iter;
     this.type = type;
+    this.done = false;
   }
 
   get finished() {
@@ -1620,8 +1620,14 @@ class AsyncIterator {
   }
 
   async next() {
-    if (!await this.iter.next())
+    if (!await this.iter.next()) {
+      if (!this.done) {
+        await this.iter.end();
+        this.done = true;
+      }
+
       return { value: undefined, done: true };
+    }
 
     const key = this.iter.key;
     const value = this.iter.value;
@@ -1646,14 +1652,20 @@ class AsyncIterator {
       done: true
     };
 
-    await this.iter.end();
+    if (!this.done) {
+      await this.iter.end();
+      this.done = true;
+    }
 
     return result;
   }
 
   async throw(err) {
     try {
-      await this.iter.end();
+      if (!this.done) {
+        await this.iter.end();
+        this.done = true;
+      }
     } catch (e) {
       ;
     }


### PR DESCRIPTION
Properly clean up the iterators when using async iterators. If `end` on iterator is not called, iterators will be around until db closes, this is will clean up those resources much sooner.