### PR TITLE
fix: `std::memory_order::memory_order_relaxed` -> `std::memory_order_relaxed`

### DIFF
--- a/deps/leveldb/util/env_posix.cc
+++ b/deps/leveldb/util/env_posix.cc
@@ -814,7 +814,7 @@ class SingletonEnv {
  public:
   SingletonEnv() {
 #if !defined(NDEBUG)
-    env_initialized_.store(true, std::memory_order::memory_order_relaxed);
+    env_initialized_.store(true, std::memory_order_relaxed);
 #endif  // !defined(NDEBUG)
     static_assert(sizeof(env_storage_) >= sizeof(EnvType),
                   "env_storage_ will not fit the Env");
@@ -831,7 +831,7 @@ class SingletonEnv {
 
   static void AssertEnvNotInitialized() {
 #if !defined(NDEBUG)
-    assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
+    assert(!env_initialized_.load(std::memory_order_relaxed));
 #endif  // !defined(NDEBUG)
   }
 


### PR DESCRIPTION
seeing build failure as below while building hsd 7.0.0

```
  npm error ../deps/leveldb/util/env_posix.cc:817:34: error: no member named 'memory_order_relaxed' in 'std::memory_order'; did you mean 'std::memory_order_relaxed'?
  npm error   817 |     env_initialized_.store(true, std::memory_order::memory_order_relaxed);
  npm error       |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  npm error       |                                  std::memory_order_relaxed
  npm error /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__atomic/memory_order.h:43:23: note: 'std::memory_order_relaxed' declared here
  npm error    43 | inline constexpr auto memory_order_relaxed = memory_order::relaxed;
  npm error       |                       ^
  npm error ../deps/leveldb/util/env_posix.cc:834:35: error: no member named 'memory_order_relaxed' in 'std::memory_order'; did you mean 'std::memory_order_relaxed'?
  npm error   834 |     assert(!env_initialized_.load(std::memory_order::memory_order_relaxed));
  npm error       |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  npm error       |                                   std::memory_order_relaxed
  npm error /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/assert.h:75:25: note: expanded from macro 'assert'
  npm error    75 |     (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)
  npm error       |                         ^
  npm error /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__atomic/memory_order.h:43:23: note: 'std::memory_order_relaxed' declared here
  npm error    43 | inline constexpr auto memory_order_relaxed = memory_order::relaxed;
  npm error       |                       ^
  npm error 2 errors generated.
```

This is due to `std::memory_order::memory_order_relaxed` is removed since C++ 20: https://en.cppreference.com/w/cpp/atomic/memory_order.

upstream has already patched as https://github.com/google/leveldb/pull/965

relates to https://github.com/Homebrew/homebrew-core/pull/200615

cc @nodech 